### PR TITLE
ubuntuのimageを最新に変更

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   shuffle:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby


### PR DESCRIPTION
Ubuntu 20.04 Actions runner imageが2025/04/15から使えなくなったので、最新の24.04にimageを変更